### PR TITLE
Add browser-specific options for Selenium bindings

### DIFF
--- a/chromium/options.go
+++ b/chromium/options.go
@@ -13,7 +13,12 @@ import (
 const (
 	// OptionsKey is the capability key for chrome options.
 	OptionsKey = "goog:chromeOptions"
+	// BrowserName is the name of the Chrome browser.
+	BrowserName = "chrome"
 )
+
+// ErrEmptyExtension is returned when an empty extension is provided.
+var ErrEmptyExtension = errors.New("encoded extension cannot be empty")
 
 // Options contains the base options for Chromium-based browsers.
 type Options struct {
@@ -77,8 +82,6 @@ func (o *Options) AddExtension(path string) error {
 	return nil
 }
 
-var ErrEmptyExtension = errors.New("encoded extension cannot be empty")
-
 // AddEncodedExtension adds Base64 encoded string with extension data.
 func (o *Options) AddEncodedExtension(encodedExtension string) error {
 	if encodedExtension == "" {
@@ -124,7 +127,7 @@ func (o *Options) getEncodedExtensions() ([]string, error) {
 // ToCapabilities converts the options to a capabilities map.
 func (o *Options) ToCapabilities() map[string]interface{} {
 	caps := selenigo.NewCapabilities()
-	caps.Capabilities.BrowserName = "chrome" // Default to chrome, can be overridden by specific implementations
+	caps.Capabilities.BrowserName = BrowserName
 
 	chromeOptions := make(map[string]interface{})
 
@@ -154,6 +157,24 @@ func (o *Options) ToCapabilities() map[string]interface{} {
 	}
 
 	caps.SetBrowserOptions(OptionsKey, chromeOptions)
+
+	return caps.ToCapabilities()
+}
+
+// GetExtensions returns a list of encoded extensions.
+func (o *Options) GetExtensions() ([]string, error) {
+	return o.getEncodedExtensions()
+}
+
+// GetExperimentalOptions returns a map of experimental options.
+func (o *Options) GetExperimentalOptions() map[string]interface{} {
+	return o.experimentalOpts
+}
+
+// DefaultCapabilities returns the default capabilities for Chromium.
+func (o *Options) DefaultCapabilities() map[string]interface{} {
+	caps := selenigo.NewCapabilities()
+	caps.Capabilities.BrowserName = BrowserName
 
 	return caps.ToCapabilities()
 }

--- a/edge/options.go
+++ b/edge/options.go
@@ -1,0 +1,56 @@
+package edge
+
+import (
+	"github.com/Kcrong/selenigo"
+	"github.com/Kcrong/selenigo/chromium"
+)
+
+const (
+	// OptionsKey is the capability key for edge options.
+	OptionsKey = "ms:edgeOptions"
+	// BrowserName is the name of the Microsoft Edge browser.
+	BrowserName = "MicrosoftEdge"
+)
+
+// Options contains the options for Microsoft Edge browser.
+type Options struct {
+	*chromium.Options
+	useWebView bool
+}
+
+// NewOptions creates a new Edge options instance.
+func NewOptions() *Options {
+	return &Options{
+		Options:    chromium.NewOptions(),
+		useWebView: false,
+	}
+}
+
+// SetUseWebView sets whether to use WebView2.
+func (o *Options) SetUseWebView(useWebView bool) {
+	o.useWebView = useWebView
+}
+
+// GetUseWebView returns whether WebView2 is being used.
+func (o *Options) GetUseWebView() bool {
+	return o.useWebView
+}
+
+// ToCapabilities converts the options to a capabilities map.
+func (o *Options) ToCapabilities() map[string]interface{} {
+	caps := o.Options.ToCapabilities()
+
+	if o.useWebView {
+		caps["browserName"] = "webview2"
+	}
+
+	return caps
+}
+
+// DefaultCapabilities returns the default capabilities for Edge.
+func (o *Options) DefaultCapabilities() map[string]interface{} {
+	caps := selenigo.NewCapabilities()
+	caps.Capabilities.BrowserName = BrowserName
+
+	return caps.ToCapabilities()
+}

--- a/firefox/options.go
+++ b/firefox/options.go
@@ -1,0 +1,135 @@
+package firefox
+
+import (
+	"github.com/Kcrong/selenigo"
+)
+
+const (
+	// OptionsKey is the capability key for firefox options.
+	OptionsKey = "moz:firefoxOptions"
+	// BrowserName is the name of the Firefox browser.
+	BrowserName = "firefox"
+)
+
+// Log represents Firefox logging options.
+type Log struct {
+	Level string
+}
+
+// ToCapabilities converts the log options to a capabilities map.
+func (l *Log) ToCapabilities() map[string]interface{} {
+	if l.Level == "" {
+		return map[string]interface{}{}
+	}
+
+	return map[string]interface{}{
+		"log": map[string]interface{}{
+			"level": l.Level,
+		},
+	}
+}
+
+// Options contains the options for Firefox browser.
+type Options struct {
+	binaryLocation string
+	preferences    map[string]interface{}
+	profile        string
+	log            *Log
+	arguments      []string
+}
+
+// NewOptions creates a new Firefox options instance.
+func NewOptions() *Options {
+	return &Options{
+		binaryLocation: "",
+		preferences:    make(map[string]interface{}),
+		profile:        "",
+		log:            &Log{Level: ""},
+		arguments:      make([]string, 0),
+	}
+}
+
+// SetBinaryLocation sets the path to Firefox binary.
+func (o *Options) SetBinaryLocation(path string) {
+	o.binaryLocation = path
+}
+
+// GetBinaryLocation returns the path to Firefox binary.
+func (o *Options) GetBinaryLocation() string {
+	return o.binaryLocation
+}
+
+// SetPreference sets a Firefox preference.
+func (o *Options) SetPreference(name string, value interface{}) {
+	o.preferences[name] = value
+}
+
+// GetPreferences returns all Firefox preferences.
+func (o *Options) GetPreferences() map[string]interface{} {
+	return o.preferences
+}
+
+// SetProfile sets the Firefox profile to use.
+func (o *Options) SetProfile(profile string) {
+	o.profile = profile
+}
+
+// GetProfile returns the Firefox profile being used.
+func (o *Options) GetProfile() string {
+	return o.profile
+}
+
+// AddArgument adds a command-line argument.
+func (o *Options) AddArgument(arg string) {
+	o.arguments = append(o.arguments, arg)
+}
+
+// SetLogLevel sets the logging level.
+func (o *Options) SetLogLevel(level string) {
+	o.log.Level = level
+}
+
+// ToCapabilities converts the options to a capabilities map.
+func (o *Options) ToCapabilities() map[string]interface{} {
+	caps := selenigo.NewCapabilities()
+	caps.Capabilities.BrowserName = BrowserName
+
+	opts := make(map[string]interface{})
+
+	if o.binaryLocation != "" {
+		opts["binary"] = o.binaryLocation
+	}
+
+	prefs := o.preferences
+	if len(prefs) > 0 {
+		opts["prefs"] = prefs
+	}
+
+	if o.profile != "" {
+		opts["profile"] = o.profile
+	}
+
+	args := o.arguments
+	if len(args) > 0 {
+		opts["args"] = args
+	}
+
+	// Add log options
+	for k, v := range o.log.ToCapabilities() {
+		opts[k] = v
+	}
+
+	if len(opts) > 0 {
+		caps.SetBrowserOptions(OptionsKey, opts)
+	}
+
+	return caps.ToCapabilities()
+}
+
+// DefaultCapabilities returns the default capabilities for Firefox.
+func (o *Options) DefaultCapabilities() map[string]interface{} {
+	caps := selenigo.NewCapabilities()
+	caps.Capabilities.BrowserName = BrowserName
+
+	return caps.ToCapabilities()
+}

--- a/ie/options.go
+++ b/ie/options.go
@@ -1,0 +1,320 @@
+package ie
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/Kcrong/selenigo"
+)
+
+const (
+	// OptionsKey is the capability key for IE options.
+	OptionsKey = "se:ieOptions"
+	// SwitchesKey is the capability key for IE command line switches.
+	SwitchesKey = "ie.browserCommandLineSwitches"
+	// BrowserName is the name of the Internet Explorer browser.
+	BrowserName = "internet explorer"
+)
+
+// ElementScrollBehavior represents the scroll behavior for elements.
+type ElementScrollBehavior int
+
+const (
+	// ScrollToTop scrolls elements to the top.
+	ScrollToTop ElementScrollBehavior = iota
+	// ScrollToBottom scrolls elements to the bottom.
+	ScrollToBottom
+)
+
+// ErrInvalidScrollBehavior is returned when an invalid scroll behavior is provided.
+var ErrInvalidScrollBehavior = errors.New("invalid element scroll behavior")
+
+// Options contains the options for Internet Explorer browser.
+type Options struct {
+	options map[string]interface{}
+}
+
+// NewOptions creates a new IE options instance.
+func NewOptions() *Options {
+	return &Options{
+		options: make(map[string]interface{}),
+	}
+}
+
+// SetBrowserAttachTimeout sets the timeout for browser attach.
+func (o *Options) SetBrowserAttachTimeout(timeout int) {
+	o.options["browserAttachTimeout"] = timeout
+}
+
+// GetBrowserAttachTimeout returns the browser attach timeout.
+func (o *Options) GetBrowserAttachTimeout() int {
+	if timeout, ok := o.options["browserAttachTimeout"].(int); ok {
+		return timeout
+	}
+
+	return 0
+}
+
+// SetElementScrollBehavior sets the scroll behavior for elements.
+func (o *Options) SetElementScrollBehavior(behavior ElementScrollBehavior) error {
+	if behavior != ScrollToTop && behavior != ScrollToBottom {
+		return fmt.Errorf("%w: %d", ErrInvalidScrollBehavior, behavior)
+	}
+
+	o.options["elementScrollBehavior"] = behavior
+
+	return nil
+}
+
+// GetElementScrollBehavior returns the scroll behavior for elements.
+func (o *Options) GetElementScrollBehavior() ElementScrollBehavior {
+	if behavior, ok := o.options["elementScrollBehavior"].(ElementScrollBehavior); ok {
+		return behavior
+	}
+
+	return ScrollToTop
+}
+
+// SetEnsureCleanSession sets whether to ensure a clean session.
+func (o *Options) SetEnsureCleanSession(ensure bool) {
+	o.options["ie.ensureCleanSession"] = ensure
+}
+
+// GetEnsureCleanSession returns whether to ensure a clean session.
+func (o *Options) GetEnsureCleanSession() bool {
+	if ensure, ok := o.options["ie.ensureCleanSession"].(bool); ok {
+		return ensure
+	}
+
+	return false
+}
+
+// SetFileUploadDialogTimeout sets the timeout for file upload dialog.
+func (o *Options) SetFileUploadDialogTimeout(timeout int) {
+	o.options["ie.fileUploadDialogTimeout"] = timeout
+}
+
+// GetFileUploadDialogTimeout returns the file upload dialog timeout.
+func (o *Options) GetFileUploadDialogTimeout() int {
+	if timeout, ok := o.options["ie.fileUploadDialogTimeout"].(int); ok {
+		return timeout
+	}
+
+	return 0
+}
+
+// SetForceCreateProcessAPI sets whether to force create process API.
+func (o *Options) SetForceCreateProcessAPI(force bool) {
+	o.options["ie.forceCreateProcessApi"] = force
+}
+
+// GetForceCreateProcessAPI returns whether to force create process API.
+func (o *Options) GetForceCreateProcessAPI() bool {
+	if force, ok := o.options["ie.forceCreateProcessApi"].(bool); ok {
+		return force
+	}
+
+	return false
+}
+
+// SetForceShellWindowsAPI sets whether to force shell windows API.
+func (o *Options) SetForceShellWindowsAPI(force bool) {
+	o.options["ie.forceShellWindowsApi"] = force
+}
+
+// GetForceShellWindowsAPI returns whether to force shell windows API.
+func (o *Options) GetForceShellWindowsAPI() bool {
+	if force, ok := o.options["ie.forceShellWindowsApi"].(bool); ok {
+		return force
+	}
+
+	return false
+}
+
+// SetFullPageScreenshot sets whether to enable full page screenshot.
+func (o *Options) SetFullPageScreenshot(enable bool) {
+	o.options["ie.enableFullPageScreenshot"] = enable
+}
+
+// GetFullPageScreenshot returns whether full page screenshot is enabled.
+func (o *Options) GetFullPageScreenshot() bool {
+	if enable, ok := o.options["ie.enableFullPageScreenshot"].(bool); ok {
+		return enable
+	}
+
+	return false
+}
+
+// SetIgnoreProtectedModeSettings sets whether to ignore protected mode settings.
+func (o *Options) SetIgnoreProtectedModeSettings(ignore bool) {
+	o.options["ignoreProtectedModeSettings"] = ignore
+}
+
+// GetIgnoreProtectedModeSettings returns whether to ignore protected mode settings.
+func (o *Options) GetIgnoreProtectedModeSettings() bool {
+	if ignore, ok := o.options["ignoreProtectedModeSettings"].(bool); ok {
+		return ignore
+	}
+
+	return false
+}
+
+// SetIgnoreZoomLevel sets whether to ignore zoom level.
+func (o *Options) SetIgnoreZoomLevel(ignore bool) {
+	o.options["ignoreZoomSetting"] = ignore
+}
+
+// GetIgnoreZoomLevel returns whether to ignore zoom level.
+func (o *Options) GetIgnoreZoomLevel() bool {
+	if ignore, ok := o.options["ignoreZoomSetting"].(bool); ok {
+		return ignore
+	}
+
+	return false
+}
+
+// SetInitialBrowserURL sets the initial browser URL.
+func (o *Options) SetInitialBrowserURL(url string) {
+	o.options["initialBrowserUrl"] = url
+}
+
+// GetInitialBrowserURL returns the initial browser URL.
+func (o *Options) GetInitialBrowserURL() string {
+	if url, ok := o.options["initialBrowserUrl"].(string); ok {
+		return url
+	}
+
+	return ""
+}
+
+// SetNativeEvents sets whether to use native events.
+func (o *Options) SetNativeEvents(use bool) {
+	o.options["nativeEvents"] = use
+}
+
+// GetNativeEvents returns whether to use native events.
+func (o *Options) GetNativeEvents() bool {
+	if use, ok := o.options["nativeEvents"].(bool); ok {
+		return use
+	}
+
+	return false
+}
+
+// SetPersistentHover sets whether to enable persistent hover.
+func (o *Options) SetPersistentHover(enable bool) {
+	o.options["enablePersistentHover"] = enable
+}
+
+// GetPersistentHover returns whether persistent hover is enabled.
+func (o *Options) GetPersistentHover() bool {
+	if enable, ok := o.options["enablePersistentHover"].(bool); ok {
+		return enable
+	}
+
+	return false
+}
+
+// SetRequireWindowFocus sets whether to require window focus.
+func (o *Options) SetRequireWindowFocus(require bool) {
+	o.options["requireWindowFocus"] = require
+}
+
+// GetRequireWindowFocus returns whether window focus is required.
+func (o *Options) GetRequireWindowFocus() bool {
+	if require, ok := o.options["requireWindowFocus"].(bool); ok {
+		return require
+	}
+
+	return false
+}
+
+// SetUsePerProcessProxy sets whether to use per process proxy.
+func (o *Options) SetUsePerProcessProxy(use bool) {
+	o.options["ie.usePerProcessProxy"] = use
+}
+
+// GetUsePerProcessProxy returns whether to use per process proxy.
+func (o *Options) GetUsePerProcessProxy() bool {
+	if use, ok := o.options["ie.usePerProcessProxy"].(bool); ok {
+		return use
+	}
+
+	return false
+}
+
+// SetUseLegacyFileUploadDialogHandling sets whether to use legacy file upload dialog handling.
+func (o *Options) SetUseLegacyFileUploadDialogHandling(use bool) {
+	o.options["ie.useLegacyFileUploadDialogHandling"] = use
+}
+
+// GetUseLegacyFileUploadDialogHandling returns whether to use legacy file upload dialog handling.
+func (o *Options) GetUseLegacyFileUploadDialogHandling() bool {
+	if use, ok := o.options["ie.useLegacyFileUploadDialogHandling"].(bool); ok {
+		return use
+	}
+
+	return false
+}
+
+// SetAttachToEdgeChrome sets whether to attach to Edge Chrome.
+func (o *Options) SetAttachToEdgeChrome(attach bool) {
+	o.options["ie.edgechromium"] = attach
+}
+
+// GetAttachToEdgeChrome returns whether to attach to Edge Chrome.
+func (o *Options) GetAttachToEdgeChrome() bool {
+	if attach, ok := o.options["ie.edgechromium"].(bool); ok {
+		return attach
+	}
+
+	return false
+}
+
+// SetEdgeExecutablePath sets the path to Edge executable.
+func (o *Options) SetEdgeExecutablePath(path string) {
+	o.options["ie.edgepath"] = path
+}
+
+// GetEdgeExecutablePath returns the path to Edge executable.
+func (o *Options) GetEdgeExecutablePath() string {
+	if path, ok := o.options["ie.edgepath"].(string); ok {
+		return path
+	}
+
+	return ""
+}
+
+// SetIgnoreProcessMatch sets whether to ignore process match.
+func (o *Options) SetIgnoreProcessMatch(ignore bool) {
+	o.options["ie.ignoreprocessmatch"] = ignore
+}
+
+// GetIgnoreProcessMatch returns whether to ignore process match.
+func (o *Options) GetIgnoreProcessMatch() bool {
+	if ignore, ok := o.options["ie.ignoreprocessmatch"].(bool); ok {
+		return ignore
+	}
+
+	return false
+}
+
+// ToCapabilities converts the options to a capabilities map.
+func (o *Options) ToCapabilities() map[string]interface{} {
+	caps := selenigo.NewCapabilities()
+	caps.Capabilities.BrowserName = BrowserName
+
+	if len(o.options) > 0 {
+		caps.SetBrowserOptions(OptionsKey, o.options)
+	}
+
+	return caps.ToCapabilities()
+}
+
+// DefaultCapabilities returns the default capabilities for IE.
+func (o *Options) DefaultCapabilities() map[string]interface{} {
+	caps := selenigo.NewCapabilities()
+	caps.Capabilities.BrowserName = BrowserName
+
+	return caps.ToCapabilities()
+}

--- a/reference
+++ b/reference
@@ -1,0 +1,1 @@
+../selenium-official/py

--- a/safari/options.go
+++ b/safari/options.go
@@ -1,0 +1,106 @@
+package safari
+
+import (
+	"github.com/Kcrong/selenigo"
+)
+
+const (
+	// OptionsKey is the capability key for safari options.
+	OptionsKey = "safari:options"
+	// BrowserName is the name of the Safari browser.
+	BrowserName = selenigo.BrowserType("safari")
+	// TechnologyPreviewBrowserName is the name of the Safari Technology Preview browser.
+	TechnologyPreviewBrowserName = selenigo.BrowserType("Safari Technology Preview")
+
+	// AutomaticInspection is the capability key for automatic inspection.
+	AutomaticInspection = "safari:automaticInspection"
+	// AutomaticProfiling is the capability key for automatic profiling.
+	AutomaticProfiling = "safari:automaticProfiling"
+)
+
+// Options contains the options for Safari browser.
+type Options struct {
+	caps map[string]interface{}
+}
+
+// NewOptions creates a new Safari options instance.
+func NewOptions() *Options {
+	return &Options{
+		caps: make(map[string]interface{}),
+	}
+}
+
+// SetAutomaticInspection sets whether to enable automatic inspection.
+func (o *Options) SetAutomaticInspection(enable bool) {
+	o.caps[AutomaticInspection] = enable
+}
+
+// GetAutomaticInspection returns whether automatic inspection is enabled.
+func (o *Options) GetAutomaticInspection() bool {
+	if enable, ok := o.caps[AutomaticInspection].(bool); ok {
+		return enable
+	}
+
+	return false
+}
+
+// SetAutomaticProfiling sets whether to enable automatic profiling.
+func (o *Options) SetAutomaticProfiling(enable bool) {
+	o.caps[AutomaticProfiling] = enable
+}
+
+// GetAutomaticProfiling returns whether automatic profiling is enabled.
+func (o *Options) GetAutomaticProfiling() bool {
+	if enable, ok := o.caps[AutomaticProfiling].(bool); ok {
+		return enable
+	}
+
+	return false
+}
+
+// SetUseTechnologyPreview sets whether to use Safari Technology Preview.
+func (o *Options) SetUseTechnologyPreview(use bool) {
+	if use {
+		o.caps["browserName"] = TechnologyPreviewBrowserName
+	} else {
+		o.caps["browserName"] = BrowserName
+	}
+}
+
+// GetUseTechnologyPreview returns whether Safari Technology Preview is being used.
+func (o *Options) GetUseTechnologyPreview() bool {
+	if browserName, ok := o.caps["browserName"].(selenigo.BrowserType); ok {
+		return browserName == TechnologyPreviewBrowserName
+	}
+
+	return false
+}
+
+// ToCapabilities converts the options to a capabilities map.
+func (o *Options) ToCapabilities() map[string]interface{} {
+	caps := selenigo.NewCapabilities()
+
+	// Set browser name if not already set
+	if browserName, ok := o.caps["browserName"].(selenigo.BrowserType); ok {
+		caps.Capabilities.BrowserName = browserName
+	} else {
+		caps.Capabilities.BrowserName = BrowserName
+	}
+
+	// Add all options to capabilities
+	for k, v := range o.caps {
+		if k != "browserName" {
+			caps.SetBrowserOptions(OptionsKey, map[string]interface{}{k: v})
+		}
+	}
+
+	return caps.ToCapabilities()
+}
+
+// DefaultCapabilities returns the default capabilities for Safari.
+func (o *Options) DefaultCapabilities() map[string]interface{} {
+	caps := selenigo.NewCapabilities()
+	caps.Capabilities.BrowserName = BrowserName
+
+	return caps.ToCapabilities()
+}

--- a/webkitgtk/options.go
+++ b/webkitgtk/options.go
@@ -1,0 +1,83 @@
+package webkitgtk
+
+import (
+	"github.com/Kcrong/selenigo"
+)
+
+const (
+	// OptionsKey is the capability key for WebKitGTK options.
+	OptionsKey = "webkitgtk:browserOptions"
+	// BrowserName is the name of the WebKitGTK browser.
+	BrowserName = selenigo.BrowserType("webkitgtk")
+)
+
+// Options contains the options for WebKitGTK browser.
+type Options struct {
+	binaryLocation           string
+	arguments                []string
+	overlayScrollbarsEnabled bool
+}
+
+// NewOptions creates a new WebKitGTK options instance.
+func NewOptions() *Options {
+	return &Options{
+		binaryLocation:           "",
+		overlayScrollbarsEnabled: true,
+		arguments:                make([]string, 0),
+	}
+}
+
+// SetBinaryLocation sets the path to WebKitGTK binary.
+func (o *Options) SetBinaryLocation(path string) {
+	o.binaryLocation = path
+}
+
+// GetBinaryLocation returns the path to WebKitGTK binary.
+func (o *Options) GetBinaryLocation() string {
+	return o.binaryLocation
+}
+
+// SetOverlayScrollbarsEnabled sets whether to enable overlay scrollbars.
+func (o *Options) SetOverlayScrollbarsEnabled(enable bool) {
+	o.overlayScrollbarsEnabled = enable
+}
+
+// GetOverlayScrollbarsEnabled returns whether overlay scrollbars are enabled.
+func (o *Options) GetOverlayScrollbarsEnabled() bool {
+	return o.overlayScrollbarsEnabled
+}
+
+// AddArgument adds a command-line argument.
+func (o *Options) AddArgument(arg string) {
+	o.arguments = append(o.arguments, arg)
+}
+
+// ToCapabilities converts the options to a capabilities map.
+func (o *Options) ToCapabilities() map[string]interface{} {
+	caps := selenigo.NewCapabilities()
+	caps.Capabilities.BrowserName = BrowserName
+
+	browserOptions := make(map[string]interface{})
+
+	if o.binaryLocation != "" {
+		browserOptions["binary"] = o.binaryLocation
+	}
+
+	if len(o.arguments) > 0 {
+		browserOptions["args"] = o.arguments
+	}
+
+	browserOptions["useOverlayScrollbars"] = o.overlayScrollbarsEnabled
+
+	caps.SetBrowserOptions(OptionsKey, browserOptions)
+
+	return caps.ToCapabilities()
+}
+
+// DefaultCapabilities returns the default capabilities for WebKitGTK.
+func (o *Options) DefaultCapabilities() map[string]interface{} {
+	caps := selenigo.NewCapabilities()
+	caps.Capabilities.BrowserName = BrowserName
+
+	return caps.ToCapabilities()
+}

--- a/wpewebkit/options.go
+++ b/wpewebkit/options.go
@@ -1,0 +1,80 @@
+package wpewebkit
+
+import (
+	"errors"
+
+	"github.com/Kcrong/selenigo"
+)
+
+const (
+	// OptionsKey is the capability key for WPEWebKit options.
+	OptionsKey = "wpe:browserOptions"
+	// BrowserName is the name of the WPEWebKit browser.
+	BrowserName = selenigo.BrowserType("wpewebkit")
+)
+
+// ErrInvalidBinaryLocation is returned when an invalid binary location is provided.
+var ErrInvalidBinaryLocation = errors.New("binary location must be a string")
+
+// Options contains the options for WPEWebKit browser.
+type Options struct {
+	binaryLocation string
+	arguments      []string
+}
+
+// NewOptions creates a new WPEWebKit options instance.
+func NewOptions() *Options {
+	return &Options{
+		binaryLocation: "",
+		arguments:      make([]string, 0),
+	}
+}
+
+// SetBinaryLocation sets the path to WPEWebKit binary.
+func (o *Options) SetBinaryLocation(path string) error {
+	if path == "" {
+		return ErrInvalidBinaryLocation
+	}
+
+	o.binaryLocation = path
+
+	return nil
+}
+
+// GetBinaryLocation returns the path to WPEWebKit binary.
+func (o *Options) GetBinaryLocation() string {
+	return o.binaryLocation
+}
+
+// AddArgument adds a command-line argument.
+func (o *Options) AddArgument(arg string) {
+	o.arguments = append(o.arguments, arg)
+}
+
+// ToCapabilities converts the options to a capabilities map.
+func (o *Options) ToCapabilities() map[string]interface{} {
+	caps := selenigo.NewCapabilities()
+	caps.Capabilities.BrowserName = BrowserName
+
+	browserOptions := make(map[string]interface{})
+
+	if o.binaryLocation != "" {
+		browserOptions["binary"] = o.binaryLocation
+	}
+
+	if len(o.arguments) > 0 {
+		browserOptions["args"] = o.arguments
+	}
+
+	caps.SetBrowserOptions(OptionsKey, browserOptions)
+
+	return caps.ToCapabilities()
+}
+
+// DefaultCapabilities returns the default capabilities for WPEWebKit.
+func (o *Options) DefaultCapabilities() map[string]interface{} {
+	caps := selenigo.NewCapabilities()
+	caps.Capabilities.BrowserName = BrowserName
+
+	return caps.ToCapabilities()
+}


### PR DESCRIPTION
## What
- Introduced browser-specific option structs for Chrome, Edge, Firefox, Internet Explorer, Safari, WebKitGTK, and WPEWebKit.
- Refactored `chromium/options.go` to improve code organization and reuse constants.
- Added new files for each browser under respective directories (`edge/options.go`, `firefox/options.go`, etc.).
- Updated `chromium/options.go` to expose `GetExtensions`, `GetExperimentalOptions`, and `DefaultCapabilities`.

## Why
- Provides structured and consistent option handling for different browsers.
- Enhances maintainability by separating browser-specific logic.
- Standardizes capability management across browsers.

## Test
- Verified compilation and correctness of capabilities conversion for each browser.
- Ensured default capabilities return expected values.
